### PR TITLE
Oauth2 in pyalveo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ pip-delete-this-directory.txt
 
 *.pyc
 *.bak
+
+# Development
+.project
+.pydevproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests==2.9.1
 python-dateutil==2.5.2 
+oauthlib==2.0.0
+requests-oauthlib==0.7.0


### PR DESCRIPTION
Figure it's time to pull in Oauth2 changes. It is currently in a working state, however, it expects my changes to hcsvlabs to be deployed before working. It still uses the API-Key for most communications however it has been abstracted away from the user as pyalveo will try to request it. Should it not be able to receive the API-Key, it will attempt all requests using standard OAuth2, which means it should still work after the concept of API-Keys is removed from hcsvlabs altogether. 